### PR TITLE
Enhance MD5 Performance with FastThreadLocal

### DIFF
--- a/src/main/java/io/github/sinri/keel/helper/KeelDigestHelper.java
+++ b/src/main/java/io/github/sinri/keel/helper/KeelDigestHelper.java
@@ -1,5 +1,7 @@
 package io.github.sinri.keel.helper;
 
+import io.netty.util.concurrent.FastThreadLocal;
+
 import javax.annotation.Nonnull;
 import javax.crypto.Mac;
 import javax.crypto.SecretKey;
@@ -40,13 +42,9 @@ public class KeelDigestHelper {
      */
     @Nonnull
     public String md5(@Nonnull String raw) {
-        try {
-            MessageDigest md = MessageDigest.getInstance("MD5");
-            md.update(raw.getBytes());
-            return KeelHelpers.binaryHelper().encodeHexWithLowerDigits(md.digest());
-        } catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException(e);
-        }
+        MessageDigest digest = KeelDigestHelper.getMD5MessageDigest();
+        byte[] digested = digest.digest(raw.getBytes());
+        return KeelHelpers.binaryHelper().encodeHexWithLowerDigits(digested);
     }
 
     /**
@@ -58,13 +56,9 @@ public class KeelDigestHelper {
      */
     @Nonnull
     public String MD5(@Nonnull String raw) {
-        try {
-            MessageDigest md = MessageDigest.getInstance("MD5");
-            md.update(raw.getBytes());
-            return KeelHelpers.binaryHelper().encodeHexWithUpperDigits(md.digest());
-        } catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException(e);
-        }
+        MessageDigest digest = KeelDigestHelper.getMD5MessageDigest();
+        byte[] digested = digest.digest(raw.getBytes());
+        return KeelHelpers.binaryHelper().encodeHexWithUpperDigits(digested);
     }
 
     /**
@@ -201,5 +195,19 @@ public class KeelDigestHelper {
             throw new RuntimeException(e);
         }
         return KeelHelpers.binaryHelper().encodeHexWithUpperDigits(bytes);
+    }
+
+    private static MessageDigest getMD5MessageDigest() {
+        return MD5.HOLDER.get();
+    }
+
+    private static class MD5 {
+
+        private static final FastThreadLocal<MessageDigest> HOLDER = new FastThreadLocal<>() {
+            @Override
+            protected MessageDigest initialValue() throws Exception {
+                return MessageDigest.getInstance("MD5");
+            }
+        };
     }
 }

--- a/src/test/java/io/github/sinri/keel/test/lab/helper/KeelDigestHelperTest.java
+++ b/src/test/java/io/github/sinri/keel/test/lab/helper/KeelDigestHelperTest.java
@@ -1,0 +1,22 @@
+package io.github.sinri.keel.test.lab.helper;
+
+import io.github.sinri.keel.facade.KeelInstance;
+import io.github.sinri.keel.helper.KeelDigestHelper;
+import io.github.sinri.keel.tesuto.KeelTest;
+import io.github.sinri.keel.tesuto.TestUnit;
+import io.vertx.core.Future;
+
+public class KeelDigestHelperTest extends KeelTest {
+
+    @TestUnit(skip = true)
+    public Future<Void> testMD5() {
+        KeelDigestHelperTest.main(null);
+        return Future.succeededFuture();
+    }
+
+    public static void main(String[] args) {
+        KeelDigestHelper helper = KeelInstance.KeelHelpers.digestHelper();
+        assert "b70a23988f01287eb719d2b5747677d1".equals(helper.md5("124ABC哈哈😂"));
+        assert "B70A23988F01287EB719D2B5747677D1".equals(helper.MD5("124ABC哈哈😂"));
+    }
+}


### PR DESCRIPTION
Using FastThreadLocal to manage MessageDigest instances,
reducing initialization overhead and improving speed in high-concurrency scenarios.