### PR TITLE
fix：TableRow use cloneAsJson bug

### DIFF
--- a/src/main/java/io/github/sinri/keel/mysql/matrix/SimpleResultRow.java
+++ b/src/main/java/io/github/sinri/keel/mysql/matrix/SimpleResultRow.java
@@ -26,4 +26,9 @@ public class SimpleResultRow implements ResultRow {
         this.row = jsonObject;
         return this;
     }
+
+    @Override
+    public String toString() {
+        return this.toJsonObject().toString();
+    }
 }


### PR DESCRIPTION
Some TableRow have Enum, when use cloneAsJson() it will be error,so need to override SimpleResultRow.class toString()